### PR TITLE
gh-35: fix license field in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 dependencies = [
   "numpy>=2"
 ]
-license.text = "MIT"
+license.text = "BSD-3-Clause"
 
 [project.optional-dependencies]
 doc = [


### PR DESCRIPTION
Update the license field in pyproject.toml to agree with the trove classifier and LICENSE.txt.

Closes: #35