### PR TITLE
gh-37: add growth factor

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,18 +6,34 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
+
+def parse_package_authors(author_email):
+    """Get names from a package's Author-email field."""
+    import email, email.policy
+
+    msg = email.message_from_string(f"To: {author_email}", policy=email.policy.default)
+    return ", ".join(address.display_name for address in msg["to"].addresses)
+
+
+# -- Project information -----------------------------------------------------
+
 import importlib.metadata
 
-project = "cosmology.compat.camb"
-copyright = "2025, Nathaniel Starkman, Nicolas Tessore"
-author = "Nathaniel Starkman, Nicolas Tessore"
-release = importlib.metadata.version(project)
-version = release.partition("+")[0]
+metadata = importlib.metadata.metadata("cosmology.compat.camb")
+
+project = metadata["Name"]
+author = parse_package_authors(metadata["Author-email"])
+copyright = f"2025, {author}"
+release = metadata["Version"]
+version = release.partition("-")[0]
+
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = []
+extensions = [
+    "sphinx.ext.autodoc",
+]
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,3 +22,34 @@ To create a Cosmology API-compliant ``cosmo`` object, wrap CAMB's ``pars`` and
    results = camb.get_background(pars)
 
    cosmo = cosmology.compat.camb.Cosmology(pars, results)
+
+
+Reference
+---------
+
+.. currentmodule:: cosmology.compat.camb
+
+.. autodata:: K_LINEAR
+
+.. autoproperty:: Cosmology.h
+.. autoproperty:: Cosmology.H0
+.. automethod:: Cosmology.H
+.. automethod:: Cosmology.H_over_H0
+
+.. autoproperty:: Cosmology.Omega_m0
+.. automethod:: Cosmology.Omega_m
+.. autoproperty:: Cosmology.Omega_de0
+.. automethod:: Cosmology.Omega_de
+.. autoproperty:: Cosmology.Omega_k0
+.. automethod:: Cosmology.Omega_k
+
+.. autoproperty:: Cosmology.critical_density0
+
+.. autoproperty:: Cosmology.hubble_distance
+.. automethod:: Cosmology.comoving_distance
+.. automethod:: Cosmology.transverse_comoving_distance
+.. automethod:: Cosmology.angular_diameter_distance
+
+.. automethod:: Cosmology.inv_comoving_distance
+
+.. automethod:: Cosmology.growth_factor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ test = [
   "camb",
   "cosmology.api",
   "pytest",
-  "pytest-cov"
+  "pytest-cov",
+  "scipy"
 ]
 
 [project.urls]

--- a/src/cosmology/compat/camb/__init__.py
+++ b/src/cosmology/compat/camb/__init__.py
@@ -17,6 +17,10 @@ if TYPE_CHECKING:
     Array: TypeAlias = NDArray[np.float64]
 
 
+K_LINEAR: float = 1e-3
+"""Wavenumber for computations at "linear scales"."""
+
+
 @dataclass
 class Cosmology:
     """Cosmology API wrapper for CAMB *pars* and *results*."""
@@ -137,3 +141,20 @@ class Cosmology:
         if z2 is not None:
             return np.array((1 + z2) * self.results.angular_diameter_distance2(z, z2))
         return np.array((1 + z) * self.results.angular_diameter_distance(z))
+
+    def growth_factor(self, z: Array | float) -> Array:
+        """Growth factor of matter at redshift *z*.
+
+        Returns the growth factor of matter (``delta_tot`` in CAMB) at
+        linear scales.  The wavenumber for linear scales is given by
+        :data:`K_LINEAR`.
+
+        """
+        # put redshift 0 first; this will normalise the growth factor
+        _z = np.concatenate([[0.0], np.reshape(z, -1)])
+
+        # compute redshift evolution at linear scale
+        evo = self.results.get_redshift_evolution(K_LINEAR, _z, ["delta_cdm"])
+
+        # normalise growth factor and return in input shape
+        return np.reshape(evo[1:, 0] / evo[0, 0], np.shape(z))


### PR DESCRIPTION
## Description
This pull request adds the `growth_factor()` method to the CAMB wrapper.

Internally, it uses `results.get_redshift_evolution()` to compute the growth for CAMB's `delta_tot` component (CDM + baryons + nu) at a "linear scale", which is set by `cosmology.compat.camb.K_LINEAR` (set to `1e-3` by default).

Testing is gone against LCDM's $f(z) = \Omega_m(z)^\gamma$ formula. The accuracy is <0.5%, which is really quite good, considering.

Closes: #37

## PR Checklist

- [x] Give a detailed description of the PR above.
- [x] Add tests, if applicable, to ensure code coverage never decreases.
- [x] Make sure the docs are up to date, if applicable, particularly the
      docstrings and RST files in `docs` folder.
