### PR TITLE
gh-54: do not pass CAMBparams explicitly

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,8 +10,8 @@ CAMB and the `Cosmology API <https://cosmology.readthedocs.io>`_.
 Usage
 -----
 
-To create a Cosmology API-compliant ``cosmo`` object, wrap CAMB's ``pars`` and
-``results`` in ``cosmology.compat.camb.Cosmology``:
+To create a Cosmology API-compliant ``cosmo`` object, wrap CAMB's results in
+``cosmology.compat.camb.Cosmology``:
 
 .. code-block::
 
@@ -21,4 +21,4 @@ To create a Cosmology API-compliant ``cosmo`` object, wrap CAMB's ``pars`` and
    pars = camb.set_params(H0=70.0)
    results = camb.get_background(pars)
 
-   cosmo = cosmology.compat.camb.Cosmology(pars, results)
+   cosmo = cosmology.compat.camb.Cosmology(results)

--- a/src/cosmology/compat/camb/__init__.py
+++ b/src/cosmology/compat/camb/__init__.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     Array: TypeAlias = NDArray[np.float64]
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
 class Cosmology:
     """Cosmology API wrapper for CAMB *pars* and *results*."""
 
@@ -25,7 +25,7 @@ class Cosmology:
     params: CAMBparams = field(init=False)
 
     def __post_init__(self) -> None:
-        self.params = self.data.Params
+        object.__setattr__(self, "params", self.data.Params)
 
     @property
     def h(self) -> Array:

--- a/tests/camb/test_api.py
+++ b/tests/camb/test_api.py
@@ -30,6 +30,6 @@ def test_api():
     pars = camb.set_params(H0=70.0)
     results = camb.get_background(pars)
 
-    cosmo = cosmology.compat.camb.Cosmology(pars, results)
+    cosmo = cosmology.compat.camb.Cosmology(results)
 
     assert isinstance(cosmo, Cosmology)

--- a/tests/camb/test_wrapper.py
+++ b/tests/camb/test_wrapper.py
@@ -44,7 +44,7 @@ def cosmo(compare):
         nnu=0.0,
     )
     results = camb.get_background(pars)
-    return cosmology.compat.camb.Cosmology(pars, results)
+    return cosmology.compat.camb.Cosmology(results)
 
 
 def test_h(cosmo, compare):


### PR DESCRIPTION
## Description

This pull request removes the `pars` input, instead getting the parameters implicitly from the passed `results`. It also renames the fields to `data` and `params`, respectively, which is more in line with CAMB's internal names.

Closes: #54

## PR Checklist

- [x] Give a detailed description of the PR above.
- [x] Add tests, if applicable, to ensure code coverage never decreases.
- [x] Make sure the docs are up to date, if applicable, particularly the
      docstrings and RST files in `docs` folder.
